### PR TITLE
LpInterface changed 

### DIFF
--- a/include/LP_MP.h
+++ b/include/LP_MP.h
@@ -42,7 +42,7 @@ public:
    virtual MessageTypeAdapter* GetMessage(const INDEX n) const = 0;
    virtual FactorTypeAdapter* GetConnectedFactor(const INDEX i) const = 0;
    virtual bool CanSendMessage(const INDEX i) const = 0;
-   virtual REAL LowerBound() const = 0;
+   virtual REAL LowerBound() const = 0; 
    virtual std::vector<REAL> GetReparametrizedPotential() const = 0;
    //virtual PrimalSolutionStorageAdapter* AllocatePrimalSolutionStorage() const = 0;
    //virtual bool CanComputePrimalSolution() const = 0;
@@ -59,9 +59,10 @@ public:
    //virtual void WritePrimal(PrimalSolutionStorage::Element primalSolution, std::ofstream& fs) const = 0;
 
    // for the LP interface
-   virtual INDEX GetNumberOfAuxVariables() const = 0;
+   //virtual INDEX GetNumberOfAuxVariables() const = 0;
    virtual void CreateConstraints(LpInterfaceAdapter* lpInterface) const = 0;
-   virtual void ReduceLp(LpInterfaceAdapter* lpInterface) const = 0;
+   virtual void CreateAuxVariables(LpInterfaceAdapter* lpInterface) const = 0;
+   //virtual void ReduceLp(LpInterfaceAdapter* lpInterface) const = 0;
 };
 
 class MessageTypeAdapter

--- a/include/factors/simplex_factor.hxx
+++ b/include/factors/simplex_factor.hxx
@@ -109,24 +109,24 @@ public:
          return std::numeric_limits<REAL>::infinity();
       }
    }
-
-  INDEX GetNumberOfAuxVariables() const { return 0; }
-
-  template<typename REPAM_ARRAY>
-  void ReduceLp(LpInterfaceAdapter* lp,const REPAM_ARRAY& repam) const {
-    REAL lb = LowerBound(repam);
-    REAL epsi = lp->GetEpsilon();
-    for(INDEX i=0;i<repam.size();i++){
-      if(repam[i] >= lb + epsi){
-        lp->SetVariableBound(lp->GetVariable(i),0.0,0.0,false);
-      }
-    }
+   
+   void CreateAuxVariables(LpInterfaceAdapter* lp) const { 
+    
   }
   
   void CreateConstraints(LpInterfaceAdapter* lp) const { 
     LinExpr lhs = lp->CreateLinExpr();
+    REAL epsi = lp->GetEpsilon();
+    auto repam = lp->GetRepam();
+    REAL lb = LowerBound(repam);
+    
+    assert(repam.size() == lp->GetFactorSize()); 
+    assert(epsi > 0);
     for(INDEX i=0;i<lp->GetFactorSize();i++){
-      lhs += lp->GetVariable(i);
+      if(repam[i] < lb + epsi){
+        lhs += lp->GetVariable(i);
+        lp->AddObjective(i,repam[i]);
+      }
     }
     LinExpr rhs = lp->CreateLinExpr();
     rhs += 1;

--- a/include/factors_messages.hxx
+++ b/include/factors_messages.hxx
@@ -66,8 +66,8 @@ LP_MP_FUNCTION_EXISTENCE_CLASS(HasPropagatePrimal, PropagatePrimal);
 LP_MP_FUNCTION_EXISTENCE_CLASS(HasMaximizePotential, MaximizePotential);
 
 LP_MP_FUNCTION_EXISTENCE_CLASS(HasCreateConstraints, CreateConstraints);
-LP_MP_FUNCTION_EXISTENCE_CLASS(HasGetNumberOfAuxVariables, GetNumberOfAuxVariables);
-LP_MP_FUNCTION_EXISTENCE_CLASS(HasReduceLp, ReduceLp);
+//LP_MP_FUNCTION_EXISTENCE_CLASS(HasGetNumberOfAuxVariables, GetNumberOfAuxVariables);
+//LP_MP_FUNCTION_EXISTENCE_CLASS(HasReduceLp, ReduceLp);
 
 LP_MP_ASSIGNMENT_FUNCTION_EXISTENCE_CLASS(IsAssignable, operator[]);
 }
@@ -1764,7 +1764,7 @@ public:
    }
 
    constexpr static bool CanCreateConstraints()
-   {
+   { 
       //return FunctionExistence::HasCreateConstraints<FactorType,LpInterfaceAdapter*>();
       return FunctionExistence::HasCreateConstraints<FactorType,void,LpInterfaceAdapter*>();
    }
@@ -1775,7 +1775,25 @@ public:
    {
       factor_.CreateConstraints(l);
    }
+   
+   template<bool ENABLE = CanCreateConstraints()>
+   typename std::enable_if<!ENABLE>::type
+   CreateConstraintsImpl(LpInterfaceAdapter* l) const
+   {
+      throw std::runtime_error("create constraints not implemented by factor");
+   }
 
+
+   void CreateConstraints(LpInterfaceAdapter* l) const final
+   {
+      CreateConstraintsImpl(l);
+   }
+   
+   void CreateAuxVariables(LpInterfaceAdapter* l) const final{
+     factor_.CreateAuxVariables(l);
+   }
+   
+   /*
    constexpr static bool CanReduceLp()
    {
            //return FunctionExistence::HasReduceLp<FactorType,LpInterfaceAdapter*,FactorContainerType>();
@@ -1794,41 +1812,41 @@ public:
    void ReduceLp(LpInterfaceAdapter* l) const {
            ReduceLpImpl(l);
    }
+  */
   
+  /*
    constexpr static bool CanCallGetNumberOfAuxVariables()
    {
       return FunctionExistence::HasGetNumberOfAuxVariables<FactorType,INDEX>();
    }
+   */
+   
+   /*
    template<bool ENABLE = CanCallGetNumberOfAuxVariables()>
    typename std::enable_if<!ENABLE,INDEX>::type
    GetNumberOfAuxVariablesImpl() const
    {
       return 0;
    }
+   */
+   /*
    template<bool ENABLE = CanCallGetNumberOfAuxVariables()>
    typename std::enable_if<ENABLE,INDEX>::type
    GetNumberOfAuxVariablesImpl() const
    {
       return factor_.GetNumberOfAuxVariables();
    }
-  
+   */
+  /*
    INDEX GetNumberOfAuxVariables() const 
    { 
     return GetNumberOfAuxVariablesImpl();
    }
+  */
+  
+  
+  
 
-   template<bool ENABLE = CanCreateConstraints()>
-   typename std::enable_if<!ENABLE>::type
-   CreateConstraintsImpl(LpInterfaceAdapter* l) const
-   {
-      throw std::runtime_error("create constraints not implemented by factor");
-   }
-
-
-   void CreateConstraints(LpInterfaceAdapter* l) const final
-   {
-      CreateConstraintsImpl(l);
-   }
 };
 
 

--- a/include/lp_interface/lp_cplex.hxx
+++ b/include/lp_interface/lp_cplex.hxx
@@ -8,151 +8,124 @@ namespace LP_MP {
   class LpInterfaceCplex : public LpInterfaceAdapter {
   public:
 
-    LpInterfaceCplex(INDEX noVars) : env_(IloEnv()),model_(IloModel(env_)),noVars_(noVars) {
-      MainVars_ = IloNumVarArray(env_,noVars_,0.0,1.0,LpVariable::Float);
-    }
+    LpInterfaceCplex() : env_(IloEnv()),model_(IloModel(env_)),obj_(IloMinimize(env_)){ }
+
+
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    LpInterfaceCplex( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : env_(IloEnv()),model_(IloModel(env_)),obj_(IloMinimize(env_)),
+        LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,
+                          PrimalSolutionStorage(factorBegin,factorEnd),epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
+    } 
+    
     
     template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    LpInterfaceCplex(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,bool MIP = true)
-      : env_(IloEnv()),model_(IloModel(env_)) {
+    LpInterfaceCplex( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        PrimalSolutionStorage primal,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : env_(IloEnv()),model_(IloModel(env_)),obj_(IloMinimize(env_)),
+        LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,primal,epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
+    }
 
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    void Setup(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd,
+                MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd){
+            
+      CreateVariables(factorBegin,factorEnd,messageBegin,messageEnd);
+      ObjVars_ = IloNumVarArray(env_);
+      for(INDEX i=0;i<MainVars_.size();i++){
+        ObjVars_.add(MainVars_[i]);
+      }      
+      ObjValues_ = IloNumArray(env_,MainVars_.size());
       
-      noVars_ = 0;
-      noAuxVars_ = 0;
-      INDEX preAuxVars = 0;
-      INDEX noFactors = 0;
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        noVars_ += factorIt->size();
-        noAuxVars_ += factorIt->GetNumberOfAuxVariables();
-        factorIt->SetAuxOffset(preAuxVars);
-        preAuxVars = noAuxVars_;
-        noFactors++;
-      }
-      if( MIP ){
-        MainVars_ = IloNumVarArray(env_,noVars_,0.0,IloInfinity,LpVariable::Int);
-      } else {
-        MainVars_ = IloNumVarArray(env_,noVars_,0.0,IloInfinity,LpVariable::Float);
-      }
-      model_.add(MainVars_);
-      if( noAuxVars_ > 0){
-        MainAuxVars_ = IloNumVarArray(env_,noAuxVars_,-IloInfinity,IloInfinity,LpVariable::Float);
-        model_.add(MainAuxVars_);
-      }
-
-      /* Add Factor Constraints */
-      INDEX fixedVars = 0;
-      IloNumArray ObjValues(env_,noVars_); 
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        Offset_ = factorIt->GetPrimalOffset();
-        size_ = factorIt->size();
-        OffsetAux_ = factorIt->GetAuxOffset();
-        sizeAux_ = factorIt->GetNumberOfAuxVariables();
-        auto pot = factorIt->GetReparametrizedPotential();
-        for(INDEX i=0;i<size_;++i) {
-          REAL value = pot[i];
-          if( std::isfinite(value) ){
-            ObjValues[Offset_ + i] = value;
-          } else {
-            ObjValues[Offset_ + i] = 0.0;
-            GetVariable(i).setBounds(0.0,0.0);
-            fixedVars++;
-          }
-        }
-        factorIt->CreateConstraints(this);
-      }
-      //printf("Reparametrization fixed %d variables\n",fixedVars);
-      IloObjective obj = IloMinimize(env_);
-      obj.setLinearCoefs(MainVars_, ObjValues);
-      model_.add(obj);
+      Build(factorBegin,factorEnd,messageBegin,messageEnd);
+            
+      obj_.setLinearCoefs(ObjVars_,ObjValues_);
+      model_.add(obj_);
       
-      /* Add Message Constraints */
-      for(auto messageIt = messageBegin; messageIt != messageEnd; ++messageIt) {
-        leftSize_ = messageIt->GetLeftFactor()->size();
-        rightSize_ = messageIt->GetRightFactor()->size();
-        OffsetLeft_ = messageIt->GetLeftFactor()->GetPrimalOffset();
-        OffsetRight_ = messageIt->GetRightFactor()->GetPrimalOffset();
-        messageIt->CreateConstraints(this);
-      }
-
+      // Default Parameter for CPLEX
       cplex_ = IloCplex(model_);
       cplex_.setParam(IloCplex::TiLim,3600); 
       cplex_.setParam(IloCplex::Threads,1);
-      cplex_.setParam(IloCplex::MIPEmphasis, CPX_MIPEMPHASIS_FEASIBILITY); // Jan: have not tested this! find good solutions fast, don't care so much about bound
+      cplex_.setParam(IloCplex::MIPEmphasis, CPX_MIPEMPHASIS_HIDDENFEAS); // CPX_MIPEMPHASIS_FEASIBILITY
       cplex_.setParam(IloCplex::Param::MIP::Strategy::Probe, 0); // probing
-    } 
-
-    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    void ReduceLp(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,REAL epsilon){
-      epsilon_ = epsilon;
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        Offset_ = factorIt->GetPrimalOffset();
-        size_ = factorIt->size();
-        OffsetAux_ = factorIt->GetAuxOffset();
-        sizeAux_ = factorIt->GetNumberOfAuxVariables();
-        factorIt->ReduceLp(this);
-      }
     }
     
     LinExpr CreateLinExpr() { return LinExpr(env_); }
     
-    INDEX GetFactorSize() const { return size_; }
-    INDEX GetLeftFactorSize() const { return leftSize_; }
-    INDEX GetRightFactorSize() const { return rightSize_; }
-        
-    LpVariable GetVariable(const INDEX i) const { assert(i < size_);  assert(Offset_ + i < noVars_); return MainVars_[Offset_ + i]; }
-    LpVariable GetLeftVariable(const INDEX i) const { assert(i < leftSize_); assert(OffsetLeft_ + i < noVars_); return MainVars_[OffsetLeft_ + i]; }
-    LpVariable GetRightVariable(const INDEX i) const { assert(i < rightSize_); assert(OffsetRight_ + i < noVars_); return MainVars_[OffsetRight_ + i]; }
-
-    LpVariable GetAuxVariable(const INDEX i) const { assert(i < sizeAux_); return MainAuxVars_[OffsetAux_ + i]; }
-
-    REAL GetEpsilon() const { return epsilon_; }
+    void AddObjective(INDEX i,REAL value)
+    {
+      assert(i < pot_.size());
+      ObjValues_[Offset_+i]=value;
+      //obj_.setLinearCoef(GetVariable(i), value);
+      LpInterfaceAdapter::AddObjective(i,value);      
+    }  
+    
+    void CreateMainVariable(REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = LpVariable::Float;
+      if(integer){ TypeFlag = LpVariable::Int; }
+      MainVars_.push_back(IloNumVar(env_,lb,ub,TypeFlag));
+    }
+    void CreateMainVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = LpVariable::Float;
+      if(integer){ TypeFlag = LpVariable::Int; }
+      for(INDEX i=0;i<n;i++){      
+        MainVars_.push_back(IloNumVar(env_,lb,ub,TypeFlag));
+      }
+    }
+    
+    void CreateAuxVariable(REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = LpVariable::Float;
+      if(integer){ TypeFlag = LpVariable::Int; }
+      MainAuxVars_.push_back(IloNumVar(env_,lb,ub,TypeFlag));
+    }
+    void CreateAuxVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = LpVariable::Float;
+      if(integer){ TypeFlag = LpVariable::Int; }
+      for(INDEX i=0;i<n;i++){      
+        MainAuxVars_.push_back(IloNumVar(env_,lb,ub,TypeFlag));
+      }
+    } 
     
     REAL GetVariableValue(const INDEX i) const;
     REAL GetObjectiveValue() const;
     REAL GetBestBound() const;
     
-    void SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer = false);
+    
     void SetTimeLimit(REAL t){ cplex_.setParam(IloCplex::TiLim,t); }
     void SetNumberOfThreads(INDEX t){ cplex_.setParam(IloCplex::Threads,t); };
     void SetDisplayLevel(INDEX t){ 
       assert(t <= 1); 
-      //cplex_.setParam(IloCplex::TuningDisplay,t);
       if( t == 0){ cplex_.setOut(env_.getNullStream()); }
     };
     
     void addLinearEquality(LinExpr lhs,LinExpr rhs);
     void addLinearInequality(LinExpr lhs,LinExpr rhs);
-
-    template<class factor>
-    void addFactor(const factor& f,INDEX offset);
     
-    int solve();
-    int solve(PrimalSolutionStorage::Element primal) { return solve(); }
-
-    void WriteLpModel(std::string name){ cplex_.exportModel(name.c_str()); }
+    INDEX solve();
     
   private:
     IloEnv env_;
     IloModel model_;
     IloCplex cplex_;
-    IloNumVarArray MainVars_;
-    IloNumVarArray MainAuxVars_;
+    IloObjective obj_;
     
-    INDEX Offset_,OffsetAux_,OffsetLeft_,OffsetRight_;
-    INDEX size_,sizeAux_,leftSize_,rightSize_;
-    INDEX noVars_,noAuxVars_;
-    REAL epsilon_;
+    IloNumVarArray ObjVars_;
+    IloNumArray ObjValues_;
   };
-
-  template<class factor>
-  void LpInterfaceCplex::addFactor(const factor& f,INDEX offset){
-    Offset_ = offset;
-    size_ = f.size();
-    f.CreateConstraints(this);
-  }
   
-  int LpInterfaceCplex::solve(){
-    int status = 2;
+  INDEX LpInterfaceCplex::solve(){
+    INDEX status = 2;
     try{
       cplex_.solve();
       auto stat = cplex_.getCplexStatus();
@@ -187,16 +160,7 @@ namespace LP_MP {
   REAL LpInterfaceCplex::GetObjectiveValue() const{
     return cplex_.getObjValue();
   }
-  
-  void LpInterfaceCplex::SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer){
-    v.setBounds(lb,ub);
-    if(integer){
-      model_.add(IloConversion(env_, v, IloNumVar::Int));
-    } else {
-      model_.add(IloConversion(env_, v, IloNumVar::Float));
-    }
-  }
-  
+    
   void LpInterfaceCplex::addLinearEquality(LinExpr lhs,LinExpr rhs){
     model_.add(IloRange(env_,0.0,lhs-rhs,0.0));//(lhs,GRB_EQUAL,rhs);
   }

--- a/include/lp_interface/lp_gurobi.hxx
+++ b/include/lp_interface/lp_gurobi.hxx
@@ -9,157 +9,106 @@ namespace LP_MP {
   class LpInterfaceGurobi : public LpInterfaceAdapter {
   public:
 
-    LpInterfaceGurobi() : env_(GRBEnv()),model_(GRBModel(env_)){}
-  
-    LpInterfaceGurobi(INDEX noVars) : env_(GRBEnv()),model_(GRBModel(env_)),noVars_(noVars),epsilon_(std::numeric_limits<REAL>::infinity()) {
-      std::vector<double> obj(noVars_,1);
-      std::vector<char> types(noVars_,GRB_INTEGER);
-      std::vector<REAL> lb(noVars_,-std::numeric_limits<REAL>::infinity());
-      MainVars_ = model_.addVars(&lb[0],NULL,&obj[0],&types[0],NULL,noVars_);
-    }
-        
-    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    LpInterfaceGurobi(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,bool MIP = true)
-      : env_(GRBEnv()),model_(GRBModel(env_)),epsilon_(std::numeric_limits<REAL>::infinity()) {
+    LpInterfaceGurobi() : env_(GRBEnv()),model_(GRBModel(env_)){ }
 
-      // Standard Parameter for Gurobi
+
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    LpInterfaceGurobi( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : env_(GRBEnv()),model_(GRBModel(env_)),
+        LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,
+                          PrimalSolutionStorage(factorBegin,factorEnd),epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
+    } 
+    
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    LpInterfaceGurobi( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        PrimalSolutionStorage primal,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : env_(GRBEnv()),model_(GRBModel(env_)),
+        LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,primal,epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
+    }
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    void Setup(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd,
+                MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd){
+                  
+      CreateVariables(factorBegin,factorEnd,messageBegin,messageEnd);
+      model_.update();
+      Build(factorBegin,factorEnd,messageBegin,messageEnd);
+      model_.update();
+      
+      // Default Parameter for Gurobi
       model_.getEnv().set(GRB_DoubleParam_TimeLimit,3600);
       model_.getEnv().set(GRB_IntParam_Threads,1);
-      model_.getEnv().set(GRB_IntParam_MIPFocus, 1);
-      
-      noVars_ = 0;
-      noAuxVars_ = 0;
-      INDEX preAuxVars = 0;
-      INDEX noFactors = 0;
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        noVars_ += factorIt->size();
-        noAuxVars_ += factorIt->GetNumberOfAuxVariables();
-        factorIt->SetAuxOffset(preAuxVars);
-        preAuxVars = noAuxVars_;
-        noFactors++;
-      }
-      std::vector<double> obj_1(noVars_,1.0);
-      std::vector<double> obj_2(noAuxVars_,0.0);
-      std::vector<char> types_1;
-      if(MIP){
-        types_1.resize(noVars_,GRB_INTEGER);
-      } else {
-        types_1.resize(noVars_,GRB_CONTINUOUS);
-      }
-      std::vector<char> types_2(noAuxVars_,GRB_CONTINUOUS);
-      MainVars_ = model_.addVars(NULL,NULL,&obj_1[0],&types_1[0],NULL,noVars_);
-      if( noAuxVars_ > 0){
-        std::vector<REAL> lb (noAuxVars_,-std::numeric_limits<REAL>::infinity());
-        MainAuxVars_ = model_.addVars(&lb[0],NULL,&obj_2[0],&types_2[0],NULL,noAuxVars_);
-      }
-      model_.update();
-
-      /* Add Factor Constraints */
-      INDEX fixedVars = 0;
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        Offset_ = factorIt->GetPrimalOffset();
-        size_ = factorIt->size();
-        OffsetAux_ = factorIt->GetAuxOffset();
-        sizeAux_ = factorIt->GetNumberOfAuxVariables();
-        auto pot = factorIt->GetReparametrizedPotential();
-        for(INDEX i=0;i<size_;++i) {
-          REAL value = pot[i];
-          if( std::isfinite(value) ){
-            GetVariable(i).set(GRB_DoubleAttr_Obj,value);
-          } else {
-            GetVariable(i).set(GRB_DoubleAttr_Obj,0);
-            GetVariable(i).set(GRB_DoubleAttr_LB,0);
-            GetVariable(i).set(GRB_DoubleAttr_UB,0);
-            fixedVars++;
-          }
-        }
-        factorIt->CreateConstraints(this);
-      }
-      //printf("Reparametrization fixed %d variables\n",fixedVars);
-
-      /* Add Message Constraints */
-      for(auto messageIt = messageBegin; messageIt != messageEnd; ++messageIt) {
-        leftSize_ = messageIt->GetLeftFactor()->size();
-        rightSize_ = messageIt->GetRightFactor()->size();
-        OffsetLeft_ = messageIt->GetLeftFactor()->GetPrimalOffset();
-        OffsetRight_ = messageIt->GetRightFactor()->GetPrimalOffset();
-        messageIt->CreateConstraints(this);
-      }
-
-      model_.update();
-    } 
-
-    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    void ReduceLp(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,REAL epsilon){
-      epsilon_ = epsilon;
-      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-        Offset_ = factorIt->GetPrimalOffset();
-        size_ = factorIt->size();
-        OffsetAux_ = factorIt->GetAuxOffset();
-        sizeAux_ = factorIt->GetNumberOfAuxVariables();
-        factorIt->ReduceLp(this);
-      }
-      model_.update();
+      model_.getEnv().set(GRB_IntParam_MIPFocus,1); 
     }
     
     LinExpr CreateLinExpr() { return LinExpr(); }
     
-    INDEX GetFactorSize() const { return size_; }
-    INDEX GetLeftFactorSize() const { return leftSize_; }
-    INDEX GetRightFactorSize() const { return rightSize_; }
-        
-    LpVariable GetVariable(const INDEX i) const { assert(i < size_);  assert(Offset_ + i < noVars_); return MainVars_[Offset_ + i]; }
-    LpVariable GetLeftVariable(const INDEX i) const { assert(i < leftSize_); assert(OffsetLeft_ + i < noVars_); return MainVars_[OffsetLeft_ + i]; }
-    LpVariable GetRightVariable(const INDEX i) const { assert(i < rightSize_); assert(OffsetRight_ + i < noVars_); return MainVars_[OffsetRight_ + i]; }
-
-    LpVariable GetAuxVariable(const INDEX i) const { assert(i < sizeAux_); return MainAuxVars_[OffsetAux_ + i]; }
-
-    REAL GetEpsilon() const { return epsilon_; }
+    void AddObjective(INDEX i,REAL value)
+    {
+      assert(i < pot_.size()); 
+      GetVariable(i).set(GRB_DoubleAttr_Obj,value);
+      //printf("var (%d) * %.2f \n",Offset_+i,value);
+      LpInterfaceAdapter::AddObjective(i,value);      
+    }    
+    
+    void CreateMainVariable(REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = GRB_CONTINUOUS;
+      if(integer){ TypeFlag = GRB_INTEGER; }
+      MainVars_.push_back(model_.addVar(lb,ub,0.0,TypeFlag));
+    }
+    void CreateMainVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = GRB_CONTINUOUS;
+      if(integer){ TypeFlag = GRB_INTEGER; }
+      for(INDEX i=0;i<n;i++){      
+        MainVars_.push_back(model_.addVar(lb,ub,0.0,TypeFlag));
+      }
+    }
+    
+    void CreateAuxVariable(REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = GRB_CONTINUOUS;
+      if(integer){ TypeFlag = GRB_INTEGER; }
+      MainAuxVars_.push_back(model_.addVar(lb,ub,0.0,TypeFlag));
+    }
+    void CreateAuxVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+      auto TypeFlag = GRB_CONTINUOUS;
+      if(integer){ TypeFlag = GRB_INTEGER; }
+      for(INDEX i=0;i<n;i++){      
+        MainAuxVars_.push_back(model_.addVar(lb,ub,0.0,TypeFlag));
+      }
+    } 
     
     REAL GetVariableValue(const INDEX i) const;
     REAL GetObjectiveValue() const;
     REAL GetBestBound() const;
     
-    void SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer = false);
     void SetTimeLimit(REAL t){ model_.getEnv().set(GRB_DoubleParam_TimeLimit,t); }
     void SetNumberOfThreads(INDEX t){ model_.getEnv().set(GRB_IntParam_Threads,t); };
     void SetDisplayLevel(INDEX t){ assert(t <= 1); model_.getEnv().set(GRB_IntParam_OutputFlag,t); };
     
     void addLinearEquality(LinExpr lhs,LinExpr rhs);
     void addLinearInequality(LinExpr lhs,LinExpr rhs);
-
-    template<class factor>
-    void addFactor(const factor& f,INDEX offset);
     
-    int solve();
-    int solve(PrimalSolutionStorage::Element primal);
-
-    void WriteLpModel(std::string name){ model_.write(name); }
+    INDEX solve();
     
   private:
     GRBEnv env_;
     GRBModel model_;
-    LpVariable* MainVars_;
-    LpVariable* MainAuxVars_;
-    
-    INDEX Offset_,OffsetAux_,OffsetLeft_,OffsetRight_;
-    INDEX size_,sizeAux_,leftSize_,rightSize_;
-    INDEX noVars_,noAuxVars_;    
-    REAL epsilon_;
   };
-
-  template<class factor>
-  inline void LpInterfaceGurobi::addFactor(const factor& f,INDEX offset){
-    Offset_ = offset;
-    size_ = f.size();
-    f.CreateConstraints(this);
-  }
   
-  inline int LpInterfaceGurobi::solve(){
-    int status = 2;
+  INDEX LpInterfaceGurobi::solve(){
+    INDEX status = 2;
     try{
-      model_.update();
-
       model_.optimize();
       auto stat = model_.get(GRB_IntAttr_Status);
       //std::cout << "Gurobi Status: " << stat << std::endl;
@@ -183,66 +132,30 @@ namespace LP_MP {
     }
     return status;
   }
+  
+  void LpInterfaceGurobi::addLinearEquality(LinExpr lhs,LinExpr rhs){
+    model_.addConstr(lhs,GRB_EQUAL,rhs);
+  }
 
-  inline int LpInterfaceGurobi::solve(PrimalSolutionStorage::Element primal){
-     // go through primal and when it is not unknownState, set variables to zero in model
-     for(INDEX i=0; i<noVars_; ++i) {
-        if(primal[i] == true) {
-           GetVariable(i).set(GRB_DoubleAttr_Obj,0);
-           GetVariable(i).set(GRB_DoubleAttr_LB,1);
-           GetVariable(i).set(GRB_DoubleAttr_UB,1);
-        } else if(primal[i] == false) {
-           GetVariable(i).set(GRB_DoubleAttr_Obj,0);
-           GetVariable(i).set(GRB_DoubleAttr_LB,0);
-           GetVariable(i).set(GRB_DoubleAttr_UB,0);
-        } else {
-           assert(primal[i] == unknownState);
-        }
-     }
-     int status = 2;
-     try{
-        model_.update();
-
-        model_.optimize();
-        status = 0;
-     }
-     catch(GRBException e) {
-        std::cout << "Error code = " << e.getErrorCode() << std::endl;
-        std::cout << e.getMessage() << std::endl;
-     }
-     // now return to original model without fixed variables
-     return status;
+    void LpInterfaceGurobi::addLinearInequality(LinExpr lhs,LinExpr rhs){
+    model_.addConstr(lhs,GRB_LESS_EQUAL,rhs);
   }
 
   inline REAL LpInterfaceGurobi::GetVariableValue(const INDEX i) const{
     assert(i < noVars_);
-    return MainVars_[i].get(GRB_DoubleAttr_X);
+    if(primal_[i] == false){
+      return 0.0;
+    }
+    else{
+      return MainVars_[i].get(GRB_DoubleAttr_X);
+    }
   }
 
-  inline REAL LpInterfaceGurobi::GetObjectiveValue() const{
+  REAL LpInterfaceGurobi::GetObjectiveValue() const{
     return model_.get(GRB_DoubleAttr_ObjVal);
   }
   
-  inline void LpInterfaceGurobi::SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer){
-    v.set(GRB_DoubleAttr_LB,lb);
-    v.set(GRB_DoubleAttr_UB,ub);
-    if(integer){
-      v.set(GRB_CharAttr_VType,'I');
-    } else {
-      v.set(GRB_CharAttr_VType,'C');
-    }
-  }
-  
-  inline void LpInterfaceGurobi::addLinearEquality(LinExpr lhs,LinExpr rhs){
-    model_.addConstr(lhs,GRB_EQUAL,rhs);
-  }
-
-  inline void LpInterfaceGurobi::addLinearInequality(LinExpr lhs,LinExpr rhs){
-    model_.addConstr(lhs,GRB_LESS_EQUAL,rhs);
-  }
-  
-  
-  inline REAL LpInterfaceGurobi::GetBestBound() const{
+  REAL LpInterfaceGurobi::GetBestBound() const{
     REAL bound = 0.0;
     if(model_.get(GRB_IntAttr_IsMIP)){
       bound = model_.get(GRB_DoubleAttr_ObjBound);

--- a/include/lp_interface/lp_interface.h
+++ b/include/lp_interface/lp_interface.h
@@ -9,7 +9,7 @@
 #elif USE_CPLEX
 #include <ilcplex/ilocplex.h>
 #elif USE_LOCALSOLVER
-#include "localsolver.h"
+#include "localsolver.h" 
 #else
 #include "lp_auxiliary.hxx"
 #endif
@@ -30,35 +30,39 @@ namespace LP_MP {
     
   class LpInterfaceAdapter {
   public:
-
+ 
     LpInterfaceAdapter(){ } 
     
     template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    LpInterfaceAdapter(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,bool integer = true)
+    LpInterfaceAdapter( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : epsilon_(epsilon),primal_(PrimalSolutionStorage(factorBegin,factorEnd)),integer_(integer),
+        LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,primal_,epsilon_,integer_)
     { } 
-        
-    virtual LinExpr CreateLinExpr() = 0;
-    
-    virtual INDEX GetFactorSize() const = 0;
-    virtual INDEX GetLeftFactorSize() const = 0;
-    virtual INDEX GetRightFactorSize() const = 0; 
-    
-    virtual LpVariable GetVariable(const INDEX i) const = 0;
-    virtual LpVariable GetLeftVariable(const INDEX i) const = 0;
-    virtual LpVariable GetRightVariable(const INDEX i) const = 0;
-
-    virtual LpVariable GetAuxVariable(const INDEX i) const = 0;
-
-    virtual REAL GetEpsilon() const = 0;
     
     template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    void ReduceLp(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,REAL epsilon){ };
+    LpInterfaceAdapter( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        PrimalSolutionStorage primal,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : epsilon_(epsilon),primal_(primal),integer_(integer)
+    { }
+    
+    virtual LinExpr CreateLinExpr() = 0;
+    
+    virtual void CreateMainVariable(REAL lb, REAL ub,bool integer = false) = 0;
+    virtual void CreateMainVariables(INDEX n,REAL lb, REAL ub,bool integer = false) = 0;
+
+    virtual void CreateAuxVariable(REAL lb, REAL ub,bool integer = false) = 0;
+    virtual void CreateAuxVariables(INDEX n,REAL lb, REAL ub,bool integer = false) = 0;
     
     virtual REAL GetVariableValue(const INDEX i) const = 0;
     virtual REAL GetObjectiveValue() const = 0;
     virtual REAL GetBestBound() const = 0;
     
-    virtual void SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer = false) = 0;
     virtual void SetTimeLimit(REAL t) = 0;
     virtual void SetNumberOfThreads(INDEX t) = 0;
     virtual void SetDisplayLevel(INDEX t) = 0;
@@ -66,12 +70,96 @@ namespace LP_MP {
     virtual void addLinearEquality(LinExpr lhs,LinExpr rhs) = 0;
     virtual void addLinearInequality(LinExpr lhs,LinExpr rhs) = 0;
     
-    virtual int solve() = 0;
-    virtual int solve(PrimalSolutionStorage::Element primal) = 0;
-
-    virtual void WriteLpModel(std::string name) = 0;
+    virtual INDEX solve() = 0;
     
+    virtual void AddObjective(INDEX i,REAL value){ /* Have to be reimplemented by the subclass */
+      primal_[Offset_ + i] = unknownState;
+    }
+    
+    INDEX GetFactorSize() const { return size_; }
+    INDEX GetLeftFactorSize() const { return leftSize_; }
+    INDEX GetRightFactorSize() const { return rightSize_; }
+    
+    LpVariable GetVariable(const INDEX i) const 
+    { assert(i < size_);  assert(Offset_ + i < noVars_); return MainVars_[Offset_ + i]; }
+    
+    LpVariable GetLeftVariable(const INDEX i) const 
+    { assert(i < leftSize_); assert(OffsetLeft_ + i < noVars_); return MainVars_[OffsetLeft_ + i]; }
+    
+    LpVariable GetRightVariable(const INDEX i) const 
+    { assert(i < rightSize_); assert(OffsetRight_ + i < noVars_); return MainVars_[OffsetRight_ + i]; }
+    
+    LpVariable GetAuxVariable(const INDEX i) const { assert(i < noAuxVars_); return MainAuxVars_[OffsetAux_ + i]; }
+
+    REAL GetEpsilon() const { return epsilon_; }
+    
+    std::vector<REAL>& GetRepam(){ return pot_; };
+    
+  protected:
+    std::vector<LpVariable> MainVars_;
+    std::vector<LpVariable> MainAuxVars_;
+    std::vector<REAL> pot_;
+    PrimalSolutionStorage primal_;
+    bool integer_;
+  
+    INDEX Offset_,OffsetAux_,OffsetLeft_,OffsetRight_;
+    INDEX size_,sizeAux_,leftSize_,rightSize_;
+    INDEX noVars_,noAuxVars_;    
+    REAL epsilon_;
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    void CreateVariables(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd){
+      
+      /* Create Variables */
+      MainVars_ = std::vector<LpVariable>();
+      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
+        Offset_ = factorIt->GetPrimalOffset();
+        for(INDEX i=0;i<factorIt->size();i++){
+          if(primal_[Offset_ + i] == true){
+            CreateMainVariable(1.0,1.0,integer_);
+          }
+          else if(primal_[Offset_ + i] == false){
+            CreateMainVariable(0.0,0.0,integer_);
+          } 
+          else {
+            CreateMainVariable(0.0,1.0,integer_);
+            primal_[Offset_ + i] = false;
+          }
+        }
+        
+        factorIt->SetAuxOffset(MainAuxVars_.size()); // <-- factoradapter provides this
+        factorIt->CreateAuxVariables(this); // <-- factor provides this
+      }
+      noVars_ = MainVars_.size();
+      noAuxVars_ = MainAuxVars_.size();
+    }
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    void Build(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd){
+      
+      /* Process Factors */
+      //printf("Process Factors\n");
+      for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
+        Offset_ = factorIt->GetPrimalOffset();          // <-- factoradapter provides this
+        size_ = factorIt->size();                       // <-- factoradapter provides this
+        OffsetAux_ = factorIt->GetAuxOffset();          // <-- factoradapter provides this
+        //sizeAux_ = factorIt->GetNumberOfAuxVariables(); // <-- factor provides this
+        pot_ = factorIt->GetReparametrizedPotential();  // <-- factoradapter provides this
+        //printf("Factor\n");
+        factorIt->CreateConstraints(this);              // <-- factor provides this
+      }
+            
+      /* Process Messages */
+      for(auto messageIt = messageBegin; messageIt != messageEnd; ++messageIt) {
+        leftSize_ = messageIt->GetLeftFactor()->size();               // <-- messageadapter provides this
+        rightSize_ = messageIt->GetRightFactor()->size();             // <-- messageadapter provides this
+        OffsetLeft_ = messageIt->GetLeftFactor()->GetPrimalOffset();  // <-- messageadapter provides this
+        OffsetRight_ = messageIt->GetRightFactor()->GetPrimalOffset();// <-- messageadapter provides this
+        messageIt->CreateConstraints(this);                           // <-- message provides this
+      }
+    }
   };
+  
 }
 
 #endif // LP_MP_LP_INTERFACE_HXX

--- a/include/lp_interface/lp_localsolver.hxx
+++ b/include/lp_interface/lp_localsolver.hxx
@@ -28,184 +28,117 @@ namespace LP_MP {
   class LpInterfaceLocalSolver : public LpInterfaceAdapter {
   public:
 
-    LpInterfaceLocalSolver(INDEX noVars) : noVars_(noVars),epsilon_(std::numeric_limits<REAL>::infinity()) {
-      model_ = localsolver_.getModel();
-      MainVars_ = std::vector<LpVariable>(noVars_);
-      for(INDEX i=0;i<noVars_;i++){
-        MainVars_[i] = model_.boolVar();
-      }
+    LpInterfaceLocalSolver() { }
+
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    LpInterfaceLocalSolver( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,
+                          PrimalSolutionStorage(factorBegin,factorEnd),epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
+    } 
+    
+    
+    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
+    LpInterfaceLocalSolver( FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, 
+                        MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,
+                        PrimalSolutionStorage primal,
+                        REAL epsilon = std::numeric_limits<REAL>::infinity(),
+                        bool integer = true)
+      : LpInterfaceAdapter(factorBegin,factorEnd,messageBegin,messageEnd,primal,epsilon,integer)
+    { 
+      Setup(factorBegin,factorEnd,messageBegin,messageEnd);
     }
     
     template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    LpInterfaceLocalSolver(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,bool MIP = true)
-      : epsilon_(std::numeric_limits<REAL>::infinity()) {
-
-      try{
+    void Setup(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd,
+                MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd){
+      try{           
         model_ = localsolver_.getModel();
         cb_ = FeasibleSolutionCallback();
         localsolver_.addCallback(localsolver::CT_IterationTicked,&cb_);
-        
-        noVars_ = 0;
-        noAuxVars_ = 0;
-        INDEX preAuxVars = 0;
-        INDEX noFactors = 0;
-        for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-          noVars_ += factorIt->size();
-          noAuxVars_ += factorIt->GetNumberOfAuxVariables();
-          factorIt->SetAuxOffset(preAuxVars);
-          preAuxVars = noAuxVars_;
-          noFactors++;
-        }
-      
-        MainVars_ = std::vector<LpVariable>(noVars_);
-        if(MIP){
-          for(INDEX i=0;i<noVars_;i++){
-            MainVars_[i] = model_.boolVar();
-          }        
-        } else {
-          for(INDEX i=0;i<noVars_;i++){
-            MainVars_[i] = model_.floatVar(0.0,1.0);
-          }   
-        }
-        if( noAuxVars_ > 0){
-          MainAuxVars_ = std::vector<LpVariable>(noAuxVars_);
-          for(INDEX i=0;i<noAuxVars_;i++){
-            MainAuxVars_[i] = model_.floatVar(-std::numeric_limits<REAL>::max(),std::numeric_limits<REAL>::max());
-          }
-        }
-      
-        VariableBounds_.resize(model_.getNbExpressions());
-        isBoundSet_.resize(model_.getNbExpressions(),false);
-        
         obj_ = CreateLinExpr();
-           
-        /* Add Factor Constraints */
-        INDEX fixedVars = 0;
-        for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-          Offset_ = factorIt->GetPrimalOffset();
-          size_ = factorIt->size();
-          OffsetAux_ = factorIt->GetAuxOffset();
-          sizeAux_ = factorIt->GetNumberOfAuxVariables();
-          auto pot = factorIt->GetReparametrizedPotential();
-          for(INDEX i=0;i<size_;++i) {
-            REAL value = pot[i];
-            if( std::isfinite(value) ){
-              obj_ += value*GetVariable(i);
-            } else {
-              model_.constraint(GetVariable(i) == 0);
-              fixedVars++;
-            }
-          }
-          factorIt->CreateConstraints(this);
-        }
+        
+        CreateVariables(factorBegin,factorEnd,messageBegin,messageEnd);
+        Build(factorBegin,factorEnd,messageBegin,messageEnd);
+        
         model_.minimize(obj_);
-      
-        /* Add Message Constraints */
-        for(auto messageIt = messageBegin; messageIt != messageEnd; ++messageIt) {
-          leftSize_ = messageIt->GetLeftFactor()->size();
-          rightSize_ = messageIt->GetRightFactor()->size();
-          OffsetLeft_ = messageIt->GetLeftFactor()->GetPrimalOffset();
-          OffsetRight_ = messageIt->GetRightFactor()->GetPrimalOffset();
-          messageIt->CreateConstraints(this);
-        }
-
+        
       } catch (const localsolver::LSException& e) {
         std::cout << "LSException:" << e.getMessage() << std::endl;
         exit(1);
       }
-    } 
-
-    template<typename FACTOR_ITERATOR, typename MESSAGE_ITERATOR>
-    void ReduceLp(FACTOR_ITERATOR factorBegin, FACTOR_ITERATOR factorEnd, MESSAGE_ITERATOR messageBegin, MESSAGE_ITERATOR messageEnd,REAL epsilon){
-      try{
-        epsilon_ = epsilon;
-        for(auto factorIt = factorBegin; factorIt != factorEnd; ++factorIt) {
-          Offset_ = factorIt->GetPrimalOffset();
-          size_ = factorIt->size();
-          OffsetAux_ = factorIt->GetAuxOffset();
-          sizeAux_ = factorIt->GetNumberOfAuxVariables();
-          factorIt->ReduceLp(this);
-        }
-      } catch (const localsolver::LSException& e) {
-        std::cout << "LSException:" << e.getMessage() << std::endl;
-        //exit(1);
+       
+    }
+     
+    LinExpr CreateLinExpr() { return model_.sum(); }
+    
+    void AddObjective(INDEX i,REAL value)
+    {
+      assert(i < pot_.size()); 
+      obj_ += value*GetVariable(i);
+      LpInterfaceAdapter::AddObjective(i,value);      
+    }    
+    
+    void CreateMainVariable(REAL lb, REAL ub,bool integer = false){
+      if(integer){
+        MainVars_.push_back(model_.boolVar());
+      } else {
+        MainVars_.push_back(model_.floatVar(lb,ub));
+      }
+    }
+    void CreateMainVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+      for(INDEX i=0;i<n;i++){      
+        CreateMainVariable(lb,ub,integer);
       }
     }
     
-    LinExpr CreateLinExpr() { return model_.sum(); }
-    
-    INDEX GetFactorSize() const { return size_; }
-    INDEX GetLeftFactorSize() const { return leftSize_; }
-    INDEX GetRightFactorSize() const { return rightSize_; }
-        
-    LpVariable GetVariable(const INDEX i) const { assert(i < size_);  assert(Offset_ + i < noVars_); return MainVars_[Offset_ + i]; }
-    LpVariable GetLeftVariable(const INDEX i) const { assert(i < leftSize_); assert(OffsetLeft_ + i < noVars_); return MainVars_[OffsetLeft_ + i]; }
-    LpVariable GetRightVariable(const INDEX i) const { assert(i < rightSize_); assert(OffsetRight_ + i < noVars_); return MainVars_[OffsetRight_ + i]; }
-
-    LpVariable GetAuxVariable(const INDEX i) const { assert(i < sizeAux_); return MainAuxVars_[OffsetAux_ + i]; }
-
-    REAL GetEpsilon() const { return epsilon_; }
-    
+    void CreateAuxVariable(REAL lb, REAL ub,bool integer = false){
+     if(integer){
+        MainAuxVars_.push_back(model_.boolVar());
+      } else {
+        MainAuxVars_.push_back(model_.floatVar(lb,ub));
+      }
+    }
+    void CreateAuxVariables(INDEX n,REAL lb, REAL ub,bool integer = false){
+       for(INDEX i=0;i<n;i++){      
+        CreateAuxVariable(lb,ub,integer);
+      }
+    } 
+ 
     REAL GetVariableValue(const INDEX i) const;
     REAL GetObjectiveValue() const;
     REAL GetBestBound() const;
     
-    void SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer = false);
     void SetTimeLimit(REAL t){ timelimit_ = t; };
     void SetNumberOfThreads(INDEX t){ noThreads_ = t; }//param_.setNbThreads(t); };
     void SetDisplayLevel(INDEX t){ assert(t <= 1); display_ = t; }  //param_.setVerbosity(t); };
     
     void addLinearEquality(LinExpr lhs,LinExpr rhs);
     void addLinearInequality(LinExpr lhs,LinExpr rhs);
-
-    template<class factor>
-    void addFactor(const factor& f,INDEX offset);
     
-    int solve();
-    int solve(PrimalSolutionStorage::Element primal);
-
-    void WriteLpModel(std::string name){  }
+    INDEX solve();
     
   private:
     localsolver::LocalSolver localsolver_;
     localsolver::LSModel model_;
     localsolver::LSPhase phase_; //localsolver_.createPhase();;
     localsolver::LSParam param_ = localsolver_.getParam();
-    
-    
-    std::vector<LpVariable> MainVars_;
-    std::vector<LpVariable> MainAuxVars_;
-    std::vector<LpVariable> VariableBounds_;
-    std::vector<bool> isBoundSet_;
-
+        
     LinExpr obj_;
     FeasibleSolutionCallback cb_;
     
-    INDEX Offset_,OffsetAux_,OffsetLeft_,OffsetRight_;
-    INDEX size_,sizeAux_,leftSize_,rightSize_;
-    INDEX noVars_,noAuxVars_;    
-    REAL epsilon_;
     REAL timelimit_ = 3600;
     REAL noThreads_ = 1;
     INDEX display_ = 0;
   };
-
-  template<class factor>
-  void LpInterfaceLocalSolver::addFactor(const factor& f,INDEX offset){
-    Offset_ = offset;
-    size_ = f.size();
-    f.CreateConstraints(this);
-  }
   
-  int LpInterfaceLocalSolver::solve(){
-    int status = 2;
-    try{
-      for(INDEX i=0;i<VariableBounds_.size();i++){
-        if(isBoundSet_[i]){
-          model_.constraint(VariableBounds_[i]);
-        }
-      }
-      
+  INDEX LpInterfaceLocalSolver::solve(){
+    INDEX status = 2;
+    try{      
       model_.close();
       
       localsolver::LSPhase phase_ = localsolver_.createPhase();//getPhase(0);
@@ -241,57 +174,6 @@ namespace LP_MP {
     return status;
   }
 
-  int LpInterfaceLocalSolver::solve(PrimalSolutionStorage::Element primal){
-    // go through primal and when it is not unknownState, set variables to zero in model
-         
-    int status = 2;
-    try{
-      for(INDEX i=0;i<VariableBounds_.size();i++){
-        if(isBoundSet_[i]){
-          model_.constraint(VariableBounds_[i]);
-        }
-      }      
-      
-      for(INDEX i=0; i<noVars_; ++i) {
-        if(primal[i] == true) {
-          SetVariableBound(MainVars_[i],1,1,false);
-        } else if(primal[i] == false) {
-          SetVariableBound(MainVars_[i],0,0,false);
-        } else {
-          assert(primal[i] == unknownState);
-        }
-      }
-      
-      model_.close();
-      
-      localsolver::LSPhase phase_ = localsolver_.createPhase();//getPhase(0);
-      phase_.setTimeLimit(timelimit_);
-
-      param_.setNbThreads(noThreads_);
-      param_.setVerbosity(display_);
-            
-      localsolver_.solve();
-      localsolver::LSSolution sol = localsolver_.getSolution();
-      localsolver::LSSolutionStatus stat = sol.getStatus();
-      
-      if(stat == localsolver::SS_Optimal ){
-        status = 0;
-      }
-      else if(stat == localsolver::SS_Feasible){
-        status = 3;
-      }
-      else if(stat == localsolver::SS_Infeasible){
-        status = 1;
-      }
-      
-    }
-    catch (const localsolver::LSException& e) {
-      std::cout << "LSException:" << e.getMessage() << std::endl;
-    }
-    // now return to original model without fixed variables
-    return status;
-  }
-
   REAL LpInterfaceLocalSolver::GetVariableValue(const INDEX i) const{
     try{
       assert(i < noVars_);
@@ -318,15 +200,6 @@ namespace LP_MP {
       std::cout << "LSException (GetObjetiveValue):" << e.getMessage() << std::endl;
       exit(1);
     }
-  }
-  
-  void LpInterfaceLocalSolver::SetVariableBound(LpVariable v,REAL lb,REAL ub,bool integer){
-    INDEX i = v.getIndex();
-    assert(i < VariableBounds_.size());
-    if(!isBoundSet_[i]){
-      isBoundSet_[i] = true;
-    }
-    VariableBounds_[i] = model_.and_(lb <= v,v <= ub); 
   }
   
   void LpInterfaceLocalSolver::addLinearEquality(LinExpr lhs,LinExpr rhs){

--- a/include/solver.hxx
+++ b/include/solver.hxx
@@ -460,10 +460,10 @@ public:
             FactorMessageIterator<decltype(MessageWrapper),MessageTypeAdapter> MessageItBegin(MessageWrapper,0);
             FactorMessageIterator<decltype(MessageWrapper),MessageTypeAdapter> MessageItEnd(MessageWrapper,SOLVER::lp_.GetNumberOfMessages());
 
-            LP_INTERFACE solver(FactorItBegin,FactorItEnd,MessageItBegin,MessageItEnd,!RELAX_.getValue());
+      LP_INTERFACE solver(FactorItBegin,FactorItEnd,MessageItBegin,MessageItEnd,VariableThreshold_,!RELAX_.getValue());
 
-            solver.ReduceLp(FactorItBegin,FactorItEnd,MessageItBegin,MessageItEnd,VariableThreshold_);
-            guard.unlock();
+      //solver.ReduceLp(FactorItBegin,FactorItEnd,MessageItBegin,MessageItEnd,VariableThreshold_);
+      guard.unlock();
 
             solver.SetTimeLimit(timelimit_.getValue());
             solver.SetNumberOfThreads(LpThreadsArg_.getValue());
@@ -542,9 +542,9 @@ public:
       SOLVER::PostIterate(c);
 
       if( curIter_ % LpInterval_.getValue() == 0 ){
-              std::unique_lock<std::mutex> WakeUpGuard(WakeLpSolverMutex_);
-              WakeLpSolverCond.notify_one();
-              //std::this_thread::sleep_for(std::chrono::milliseconds(50)); // Jan: why sleep here?
+        std::unique_lock<std::mutex> WakeUpGuard(WakeLpSolverMutex_);
+        WakeLpSolverCond.notify_one();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50)); // Without sleep, the next iteration will block the execution of the LpInterface
       }
       ++curIter_;
     }

--- a/solvers/discrete_tomography/discrete_tomography_cplex.cpp
+++ b/solvers/discrete_tomography/discrete_tomography_cplex.cpp
@@ -2,14 +2,4 @@
 #include "lp_interface/lp_cplex.hxx"
 #include "visitors/standard_visitor.hxx"
 using namespace LP_MP;
-LP_MP_CONSTRUCT_SOLVER_WITH_INPUT_AND_LPVISITOR(FMC_DT, DiscreteTomographyTextInput::ParseProblem<FMC_DT>, StandardTighteningVisitor, LpInterfaceCplex);
-/*
-int main(int argc, char* argv[])                                      
-{                                                                     
-  //VSolver<FMC_DT,StandardTighteningVisitor<Solver<FMC_DT> >> solver(argc,argv);                             
-  
-  LpRoundingSolver<FMC_DT,LpInterfaceGurobi> solver(argc,argv);  
-  solver.ReadProblem(DiscreteTomographyTextInput::ParseProblem);
-  return solver.Solve();                                              
-}
-*/
+LP_MP_CONSTRUCT_SOLVER_WITH_INPUT_AND_VISITOR_LP(FMC_DT, DiscreteTomographyTextInput::ParseProblem<FMC_DT>, StandardTighteningVisitor, LpInterfaceCplex);

--- a/solvers/discrete_tomography/discrete_tomography_localsolver.cpp
+++ b/solvers/discrete_tomography/discrete_tomography_localsolver.cpp
@@ -2,5 +2,4 @@
 #include "lp_interface/lp_localsolver.hxx"
 #include "visitors/standard_visitor.hxx"
 using namespace LP_MP;
-//LP_MP_CONSTRUCT_SOLVER_WITH_INPUT_AND_LPVISITOR(FMC_DT, DiscreteTomographyTextInput::ParseProblem, StandardTighteningVisitor, LpInterfaceLocalSolver);
-LP_MP_CONSTRUCT_SOLVER_WITH_INPUT_AND_LPVISITOR(FMC_DT, DiscreteTomographyTextInput::ParseProblem<FMC_DT>, StandardTighteningVisitor, LpInterfaceLocalSolver);
+LP_MP_CONSTRUCT_SOLVER_WITH_INPUT_AND_VISITOR_LP(FMC_DT, DiscreteTomographyTextInput::ParseProblem<FMC_DT>, StandardTighteningVisitor, LpInterfaceLocalSolver);


### PR DESCRIPTION
Up to now, the method CreateConstraints cannot change variable bounds in the LpInterface! Instead of setting bounds we add only these variables to constraints and objective, which have to be considered.

See examples in the discrete tomography counting factor or simplex factor.

